### PR TITLE
Feature: Makes cors Access-Control-Allow-Headers configurable

### DIFF
--- a/api-gateway.js
+++ b/api-gateway.js
@@ -24,7 +24,8 @@ var util = require("util");
 
 app.use(cors({
     origin: conf.allowOrigin,
-    credentials: true
+    credentials: true,
+    allowedHeaders: conf.allowedHeaders
 }));
 app.use(timeout(conf.httpTimeout));
 app.use(bodyParser.json({

--- a/conf.js
+++ b/conf.js
@@ -7,6 +7,9 @@ module.exports = {
   // Example: `*`, `http://www.example.com`,  `http://www.example.com,http://localhost:9000`
   allowOrigin: parseArray(process.env.ALLOW_ORIGIN) || '*',
 
+  // Specify allowed headers for CORS, can be a comma separated string if multiple
+  allowedHeaders: process.env.ALLOWED_HEADERS || "content-type",
+
   // If stack traces should be leaked error responses
   printStacktrace: parseBool(process.env.PRINT_STACKTRACE, true),
 


### PR DESCRIPTION
Makes it possible to configure value of `Access-Control-Allow-Headers` so that any clients can use custom headers. 