### PR TITLE
Feature: Adds public routes that will skip decode of token

### DIFF
--- a/api-gateway.js
+++ b/api-gateway.js
@@ -56,19 +56,26 @@ app.get("/health", function (req, res) {
     });
 });
 
-app.use((httpReq, httpRes, next) => {
+app.use(async (httpReq, httpRes, next) => {
     const reqId = uuid.v4();
     const reqStartTime = Date.now();
 
     logRequest(reqId, httpReq);
-
-    decodeToken(httpReq, reqId)
-        .then(decodedToken => sendInternalRequest(httpReq, reqId, decodedToken))
-        .then(internalRes => {
-            logResponse(reqId, internalRes, reqStartTime);
-            return sendHttpReponse(reqId, internalRes, httpRes);
-        })
-        .catch(err => handleError(err, httpRes, reqId, reqStartTime));
+    
+    try {
+        // Decode JWT token (provided as cookie or in header) if route is not public
+        let decodedToken = isPublicRoute(httpReq) ? {} : await decodeToken(httpReq, reqId);
+        
+        // Translate http request to bus request and post it internally on bus
+        const internalRes = await sendInternalRequest(httpReq, reqId, decodedToken);
+        
+        logResponse(reqId, internalRes, reqStartTime);
+        
+        // Translate bus response to a HTTP response and send back to user
+        sendHttpReponse(reqId, internalRes, httpRes);
+    } catch(err) {
+        handleError(err, httpRes, reqId, reqStartTime);
+    }
 });
 
 app.use((err, req, res, next) => {
@@ -356,6 +363,16 @@ function isTrace() {
 
 function isMultipart(httpReq) {
     return httpReq.headers["content-type"] && httpReq.headers["content-type"].includes("multipart");
+}
+
+/**
+ * Checks if request is a public route and hence not needed to 
+ * decode cookie or token.
+ * 
+ * @param {Object} req 
+ */
+function isPublicRoute(req) {
+    return conf.publicRoutes.includes(req.path);
 }
 
 module.exports = {

--- a/conf.js
+++ b/conf.js
@@ -45,7 +45,10 @@ module.exports = {
 
   // Adds no cache headers (Cache-control, Pragma and Expires) to instruct
   // clients not to cache any responses. Etags will be used by default.
-  noCache: process.env.NO_CACHE === "true"
+  noCache: process.env.NO_CACHE === "true",
+
+  // Public routes that if hit, will not attempt to decode cookie/token even though it exists
+  publicRoutes: (process.env.PUBLIC_ROUTES || "/auth/cookie,/auth/token").split(",")
 
 };
 


### PR DESCRIPTION
Adds `PUBLIC_ROUTES` that if set will skip decode of token.

This defaults to auth routes so that auth will not fail if an expired JWT cookie/token is included in req.