### PR TITLE
Feature: Rewrites dots in paths into {dot}

### DIFF
--- a/spec/api-gateway.spec.js
+++ b/spec/api-gateway.spec.js
@@ -79,6 +79,34 @@ describe("API Gateway", () => {
 
     });
 
+    it("should create and recieve bus message for HTTP GET that includes dot in path", (done) => {
+        bus.subscribe("http.get.foo.:paramWithDot.foo", (req) => {
+            expect(req.path).toBe("/foo/foo.bar/foo");
+            expect(req.method).toBe("GET");
+            expect(req.reqId).toBeDefined();
+            // TODO: Update this when fruster-bus rewrites into dots
+            expect(req.params.paramWithDot).toBe("foo{dot}bar");            
+
+            return {
+                status: 200,
+                headers: {
+                    "A-Header": "foo"
+                },
+                data: {
+                    foo: "bar"
+                }
+            };
+        });
+
+        get("/foo/foo.bar/foo", (error, response, body) => {
+            expect(response.statusCode).toBe(200);            
+            expect(body.data.foo).toBe("bar");            
+
+            done();
+        });
+
+    });
+
     it("should get no cache headers on HTTP response when NO_CACHE is true", (done) => {
         conf.noCache = true;
 

--- a/utils.js
+++ b/utils.js
@@ -1,10 +1,13 @@
-var uuid = require("uuid");
+const uuid = require("uuid");
+
+const ESCAPE_DOTS_REGEPX = /\./g; 
 
 module.exports = {
 
   createSubject: req => {
-    var method = req.method;
-    var path = req.path.split("/");
+    const method = req.method;
+    const path = req.path.replace(ESCAPE_DOTS_REGEPX, "{dot}").split("/");
+  
     return ["http", method]
       .concat(path)
       .filter(function (val) {
@@ -14,7 +17,7 @@ module.exports = {
   },
 
   createRequest: (req, reqId, user) => {
-    var o = {
+    let o = {
       reqId: reqId,
       method: req.method,
       path: req.path,
@@ -24,7 +27,7 @@ module.exports = {
     };
 
     if (user) {
-      o.user = user;
+      o.user = user;  
     }
 
     return o;


### PR DESCRIPTION
Handles cases when HTTP path contains dots so NATS subject does not break.

Closes #46 