### PR TITLE
[Feature] Text based bodies

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,3 @@
-const uuid = require("uuid");
-
 const ESCAPE_DOTS_REGEPX = /\./g;
 
 module.exports = {
@@ -17,7 +15,7 @@ module.exports = {
 
 		return ["http", method]
 			.concat(path)
-			.filter(function(val) {
+			.filter(function (val) {
 				return val;
 			})
 			.join(".")


### PR DESCRIPTION
This PR adds functionality to handle text based content. 

API Gateway can for example now:

* Accept XML that is POSTed and pass it on as a data string to internal services
* Respond with any type of text based content (`text/*` and `application/xml` is supported) if such a content-type is set in response

