### PR TITLE
[FIX] Sets charset and decodes base64 response data

### DIFF
--- a/api-gateway.js
+++ b/api-gateway.js
@@ -155,7 +155,11 @@ function handleBusErrorResponse(err, httpRes, reqId) {
 		err.status = 404;
 		httpRes.status(404);
 	} else {
-		httpRes.status(err.status);
+		httpRes.status(err.status || 500);
+	}
+
+	if (httpRes.statusCode > 499) {
+		log.error(err);
 	}
 
 	setRequestId(reqId, err);
@@ -342,7 +346,11 @@ function sendHttpResponse(reqId, busResponse, httpResponse) {
 	if (isTextResponse(busResponse)) {
 		httpResponse.send(busResponse.data);
 	} else if (isBinaryResponse(busResponse)) {
-		httpResponse.send(busResponse.data);
+		const contentType = getContentType(busResponse);
+
+		httpResponse
+			.set("Content-Type", contentType + "; charset=binary")
+			.send(Buffer.from(busResponse.data, "base64"));
 	} else {
 		httpResponse.json(conf.unwrapMessageData ? busResponse.data : utils.sanitizeResponse(busResponse));
 	}


### PR DESCRIPTION
As follow up on previous PR #68 this adds charset in `Content-Type` and handles binary bus `response.data` as a base64 encoded string instead of raw binary string which could break if containing chars that could not be handled.