### PR TITLE
[FIX] Do not attempt to decode jwt in ws connection is non existing

### DIFF
--- a/lib/web-bus/FrusterWebBus.js
+++ b/lib/web-bus/FrusterWebBus.js
@@ -164,8 +164,6 @@ class FrusterWebBus {
 			(socket.upgradeReq.headers.cookie && socket.upgradeReq.headers.cookie.jwt) ||
 			socket.upgradeReq.headers.Authorization;
 
-		console.log(11111, jwtToken);
-
 		if (jwtToken) jwtToken = jwtToken.replace("Bearer ", "");
 
 		socket.jwtToken = jwtToken;
@@ -354,6 +352,7 @@ class FrusterWebBus {
 	 * @param {String=} reason reason why closing
 	 */
 	_close(socket, reason) {
+		log.debug("Closing connection with reason", reason);
 		if (socket) socket.close(1011, reason);
 	}
 }


### PR DESCRIPTION
Avoids these ones (see image) that was due to fact that no JWT was provided when user was logged out, but api gateway still tried to decode the token which caused 400 Bad Request (and which for some reason made client loop and send req again). 

![image](https://user-images.githubusercontent.com/203094/55292450-7b25b700-53eb-11e9-949e-c22ae0a43fbf.png)
