### PR TITLE
[ISSUE] Changes so conf is a number so ttl index works

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -83,7 +83,7 @@ module.exports = {
 	 *
 	 * Default: 4w
 	 */
-	statsTTL: Number(ms(process.env.STATS_TTL || "4w") / 1000).toFixed(0),
+	statsTTL: parseInt((ms(process.env.STATS_TTL || "4w") / 1000) + ""),
 
 	/**
 	 * Max size of requests that we can handle.


### PR DESCRIPTION
I noticed this line in db logs:

![image](https://user-images.githubusercontent.com/203094/70563212-1fbce300-1b8e-11ea-9bc9-61309fc00549.png)

This fixes that!