### PR TITLE
JWT token via query param in ws upgrade req

### DIFF
--- a/lib/web-bus/FrusterWebBus.js
+++ b/lib/web-bus/FrusterWebBus.js
@@ -11,7 +11,6 @@ const constants = require("../constants");
 const docs = require("../docs");
 const AuthServiceClient = require("../clients/AuthServiceClient");
 const cookie = require("cookie");
-const qs = require("qs");
 
 class FrusterWebBus {
 	static get endpoints() {


### PR DESCRIPTION
Current implementation takes JWT token from cookie or from Authorization header in the upgrade request. 

As it turns out, there is no official support for setting header on the upgrade request, so for none cookie clients this becomes an issues.

This PR makes it possible to set `token` as a query param on the upgrade request instead of relying on the cookie. 

Security wise this is a gray area but if we use HTTPS which we always should, this should be fine. 