### PR TITLE
fix: adds application/pdf as binary content type

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,6 +24,7 @@ module.exports = {
 	BINARY_CONTENT_TYPES: [
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 		"application/vnd.ms-excel",
-		"application/zip"
+		"application/zip",
+		"application/pdf"
 	]
 };


### PR DESCRIPTION
Adds `application/pdf` as binary content type. When set in inbound response API gateway will now assume that `data` is base64 encoded binary and decode it and return binary response. I.e. it will be possible to download a PDF directly.  