### PR TITLE
Add image/png as a binary content type

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -25,6 +25,7 @@ module.exports = {
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 		"application/vnd.ms-excel",
 		"application/zip",
-		"application/pdf"
+		"application/pdf",
+		"image/png"
 	]
 };


### PR DESCRIPTION
Adds image/png as a binary content type so images can be generated by a service and returned as binary.